### PR TITLE
small bugfix: move get absolute url into Product model from Order model

### DIFF
--- a/website/models.py
+++ b/website/models.py
@@ -48,7 +48,13 @@ class Product(models.Model):
     description = models.TextField(blank=True, null=True)
     price = models.DecimalField(max_digits=8, decimal_places=2, null=False)
     quantity = models.IntegerField()
-    # date_added = models.DateTimeField('Date Added')
+    
+    def __str__(self):
+        return self.title
+
+    def get_absolute_url(self):
+        return "/single_product/{}".format(self.id)
+
 
 
 class Customer(models.Model):
@@ -92,13 +98,6 @@ class Order(models.Model):
 
     # def __str__(self):
     #     return self.order_date
-
-    def __str__(self):
-        return self.title
-
-    def get_absolute_url(self):
-        return "/single_product/{}".format(self.id)
-
 
 class ProductOrder(models.Model):
     """

--- a/website/templates/product_types.html
+++ b/website/templates/product_types.html
@@ -1,3 +1,6 @@
+{% extends 'main.html' %}
+{% block content %}
+
 <h1>Product Types</h1>
 
 <ol>
@@ -11,3 +14,5 @@
 
 	{% endfor %}
  </ol>
+
+ {% endblock %}


### PR DESCRIPTION
# Illegal Llamas Pull Request Template

## Status
Ready

## Description
The ```get_absolute_url``` and ```__str``` methods for the Product model were accidently moved into the Order model. This PR fixes this error.

## Related Tickets 
None

## Impacted Areas of the Application

```
    models.py
```

## Deploy Notes

For example: 
```
    git pull 
    git fetch --all
    git checkout jn-catfix
    ./migrate_llamas.sh
    python manage.py runserver
```
