### PR TITLE
Fix for delete_payment_types method

### DIFF
--- a/website/templates/main.html
+++ b/website/templates/main.html
@@ -11,10 +11,7 @@
 </head>
 <body>
 	{%include "navbar.html"%}
-	<h1>WELCOME TO BANGAZON!</h1>
-	{% if user.is_authenticated %}
-    <h1>Bangazon says... hello {{ user.username }}!</h1>
-    {% endif %}
+	<h4>BANGAZON!</h4>
 
 
 	{% block content %}{% endblock %}

--- a/website/templates/user_payment_types.html
+++ b/website/templates/user_payment_types.html
@@ -1,9 +1,12 @@
 {% extends 'main.html' %}
 {% load staticfiles %}
 
-
-
 {% block content %}
+
+{% if messages %}
+
+{% endif %}
+
 
 	<hr>
 	<h3>Your Payment Types</h3>
@@ -21,7 +24,6 @@
 		    <br>
 		    
 		{% empty %}
-			<h3>Nice try, you need to add a payment type</h3><br>
 		    <a class="btn btn-default" href="add_payment_type">Add a Payment Type</a>
 	    {% endfor %}
 	</ul>       

--- a/website/templates/user_payment_types.html
+++ b/website/templates/user_payment_types.html
@@ -3,11 +3,6 @@
 
 {% block content %}
 
-{% if messages %}
-
-{% endif %}
-
-
 	<hr>
 	<h3>Your Payment Types</h3>
 	    

--- a/website/views.py
+++ b/website/views.py
@@ -256,8 +256,12 @@ def delete_payment_type(request):
     Returns: 
     """
     if request.method == 'POST':
-        pmt_type_to_delete = request.POST['payment_type_id']
-        pmt_type = PaymentType.objects.get(pk=pmt_type_to_delete).delete()
+        try:
+            pmt_type_to_delete = request.POST['payment_type_id']
+            pmt_type = PaymentType.objects.get(pk=pmt_type_to_delete).delete()
+        except:
+            user_payment_types = PaymentType.objects.filter(customer = request.user)
+            return render(request, 'user_payment_types.html', {'user_payment_types': user_payment_types})
 
         return render(request, 'delete_payment_type.html', {'delete_payment_type': delete_payment_type})
 


### PR DESCRIPTION
# Illegal Llamas Pull Request Template

## Status
Ready

## Description
This pull request adds a try/except to the ```delete_payment_types``` method so, when a user attempts to delete a card which has a completed order associated with it, they are redirected to the page and unable to delete the card type.

## Related Tickets 
None

## Impacted Areas of the Application
Files that this PR modifies or affects in some way. 
```
    views.py
```

## Deploy Notes

```
    git pull 
    git fetch --all
    git checkout jn-fix
    ./migrate_llamas.sh
    python manage.py runserver
```
